### PR TITLE
OSGI version for jboss logging setting logmanager, log4j and slf4j as opt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,40 @@
                     </links>
                 </configuration>
             </plugin>
+	    <!-- Adding OSGI metadata to the JAR without changing the packaging type. -->
+	    <plugin>
+		<artifactId>maven-jar-plugin</artifactId>
+		<configuration>
+		    <archive>
+			<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+		    </archive>
+		</configuration>
+	    </plugin>
+	    <plugin>
+		<groupId>org.apache.felix</groupId>
+		<artifactId>maven-bundle-plugin</artifactId>
+		<version>2.1.0</version>
+		<extensions>true</extensions>
+		<configuration>
+		    <instructions>
+			<Export-Package>
+				${project.groupId}.*;version=${project.version};-split-package:=error
+                        </Export-Package>                                                
+                        <Import-Package>
+                            org.apache.log4j|org.slf4j|org.slf4j.spi|org.jboss.logmanager;resolution:=optional,*
+                        </Import-Package>            
+		    </instructions>
+		</configuration>
+		<executions>
+		    <execution>
+			<id>bundle-manifest</id>
+			<phase>process-classes</phase>
+			<goals>
+			    <goal>manifest</goal>
+			</goals>
+		    </execution>
+		</executions>
+	    </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
OSGI version for jboss logging setting logmanager, log4j and slf4j as optional
