### PR TITLE
JBLOGGING-92 Add support for ExtendedLogService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
             <version>1.6.1</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse</groupId>
+            <artifactId>org.eclipse.osgi</artifactId>
+            <version>3.8.0.v20120529-1548</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -100,16 +106,26 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.1.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
                         <Export-Package>
-                            ${project.groupId}.*;version=${project.version};-split-package:=error
+                            ${project.groupId}.*;version=${project.version};-split-package:=error;-noimport:=true
                         </Export-Package>
                         <Import-Package>
-                            org.apache.log4j|org.slf4j|org.slf4j.spi|org.jboss.logmanager;resolution:=optional,*
+                            org.apache.log4j.*;version="[1.2,2)";resolution:=optional,
+                            org.slf4j.*;version="[1.6,2)";resolution:=optional,
+                            org.jboss.logmanager.*;version="[1.2,2)";resolution:=optional,
+                            org.eclipse.equinox.log;version="[1.0,2)";resolution:=optional,
+                            org.osgi.framework.*;version="[1.3,2)",
+                            *
                         </Import-Package>
+                        <Bundle-Activator>
+                            org.jboss.logging.Activator
+                        </Bundle-Activator>
+                        <Bundle-ActivationPolicy>
+                            lazy
+                        </Bundle-ActivationPolicy> 
                     </instructions>
                 </configuration>
                 <executions>

--- a/src/main/java/org/jboss/logging/Activator.java
+++ b/src/main/java/org/jboss/logging/Activator.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2010 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+
+public class Activator implements BundleActivator {
+  
+  private static final Object LOCK = new Object();
+
+  private ServiceReference serviceReference;
+  private static Object service;
+
+  @Override
+  public void start(BundleContext context) {
+    synchronized (LOCK) {
+      // use class name to not trigger class loading so the code also works
+      // in an OSGi environment that does not have ExtendedLogService present
+      // ie. not Equinox
+      serviceReference = context.getServiceReference("org.eclipse.equinox.log.ExtendedLogService");
+      if (serviceReference != null) {
+        service = context.getService(serviceReference);
+      }
+    }
+  }
+
+  @Override
+  public void stop(BundleContext context) {
+    synchronized (LOCK) {
+      if (serviceReference != null) {
+        context.ungetService(serviceReference);
+      }
+      serviceReference = null;
+      service = null;
+    }
+
+  }
+
+  static Object getService() {
+    synchronized (LOCK) {
+      return service;
+    }
+  }
+
+}

--- a/src/main/java/org/jboss/logging/EquinoxLogger.java
+++ b/src/main/java/org/jboss/logging/EquinoxLogger.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2010 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging;
+
+import java.text.MessageFormat;
+
+
+final class EquinoxLogger extends Logger {
+
+  private static final long serialVersionUID = -5517882312696000315L;
+
+  private transient final org.eclipse.equinox.log.Logger logger;
+
+  protected EquinoxLogger(final String name, final org.eclipse.equinox.log.Logger logger) {
+    super(name);
+    this.logger = logger;
+  }
+
+  @Override
+  public boolean isEnabled(final Level level) {
+    return logger.isLoggable(translate(level));
+  }
+
+  @Override
+  protected void doLog(final Level level, final String loggerClassName, final Object message, final Object[] parameters, final Throwable thrown) {
+    final int translatedLevel = translate(level);
+    if (logger.isLoggable(translatedLevel)) try {
+      logger.log(translatedLevel, String.valueOf(parameters == null || parameters.length == 0 ? message : MessageFormat.format(String.valueOf(message), parameters)), thrown);
+    } catch (Throwable ignored) {}
+  }
+
+  @Override
+  protected void doLogf(final Level level, final String loggerClassName, final String format, final Object[] parameters, final Throwable thrown) {
+    final int translatedLevel = translate(level);
+    if (logger.isLoggable(translatedLevel)) try {
+      logger.log(translatedLevel, parameters == null ? String.format(format) : String.format(format, parameters), thrown);
+    } catch (Throwable ignored) {}
+  }
+
+  private static int translate(final Level level) {
+    if (level != null) switch (level) {
+    case FATAL: // no fatal -> use error
+    case ERROR: return org.osgi.service.log.LogService.LOG_ERROR;
+    case WARN:  return org.osgi.service.log.LogService.LOG_WARNING;
+    case INFO:  return org.osgi.service.log.LogService.LOG_INFO;
+    case DEBUG: // no trace -> treat debug and trace the same
+    case TRACE: return org.osgi.service.log.LogService.LOG_DEBUG;
+    }
+    return org.osgi.service.log.LogService.LOG_DEBUG;
+  }
+
+}

--- a/src/main/java/org/jboss/logging/EquinoxLoggerProvider.java
+++ b/src/main/java/org/jboss/logging/EquinoxLoggerProvider.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2010 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging;
+
+import org.eclipse.equinox.log.ExtendedLogService;
+
+final class EquinoxLoggerProvider extends AbstractMdcLoggerProvider implements LoggerProvider {
+
+  private final ExtendedLogService logService;
+
+  EquinoxLoggerProvider(Object logService) {
+    this.logService = (ExtendedLogService) logService;
+  }
+
+  public Logger getLogger(String name) {
+    return new EquinoxLogger(name, logService.getLogger(name));
+  }
+
+}

--- a/src/main/java/org/jboss/logging/LoggerProviders.java
+++ b/src/main/java/org/jboss/logging/LoggerProviders.java
@@ -55,6 +55,8 @@ final class LoggerProviders {
                     return tryLog4j(cl);
                 } else if ("slf4j".equalsIgnoreCase(loggerProvider)) {
                     return trySlf4j();
+                } else if ("equinox".equalsIgnoreCase(loggerProvider)) {
+                  return tryEquinox();
                 }
             }
         } catch (Throwable t) {
@@ -75,6 +77,11 @@ final class LoggerProviders {
             return trySlf4j();
         } catch (Throwable t) {
             // nope...
+        }
+        try {
+          return tryEquinox();
+        } catch (Throwable t) {
+          // nope...
         }
         return tryJDK();
     }
@@ -101,6 +108,14 @@ final class LoggerProviders {
             return new JBossLogManagerProvider();
         }
         throw new IllegalStateException();
+    }
+    
+    private static LoggerProvider tryEquinox() {
+      Object service = Activator.getService();
+      if (service != null) {
+        return new EquinoxLoggerProvider(service);
+      }
+      throw new IllegalStateException();
     }
 
     private LoggerProviders() {


### PR DESCRIPTION
We are running some JBoss libraries that use jboss-logging inside
Eclipse RCP. We'd like to centralize all logging. Unfortunately OSGi
LogService does not support named loggers, for now they're only
available through the Equinox ExtendedLogService.

This pull commit adds Equinox ExtendedLogService support and contains
the following changes:
- add EquinoxLoggerProvider
- add EquinoxLogger
- add OSGi bundle activator that looks up Equinox ExtendedLogService
- make bundle activation lazy so that the activator actually runs [1]
- change LoggerProviders to also check for Equinox ExtendedLogService
- add "equinox" flag to LoggerProviders

Care has been taken not to impact anybody not running in Equinox
- LoggerProviders does not depend on any new external classes
- the bundle activator does not depend on Equinox classes and should
  therefore run fine in other OSGi environments (eg. Felix, JBoss OSGi)
- the Equinox dependency has been marked as optional in the manifest

Even though Equinox loggers are not serializable themselves
serialization is still supported in the same was as for JDK loggers.

https://issues.jboss.org/browse/JBLOGGING-92

 [1] http://stackoverflow.com/questions/15475230/state-of-required-bundle-resolved-instead-of-active
