### PR TITLE
JBLOGGING-100 conditional string conversion

### DIFF
--- a/src/main/java/org/jboss/logging/JBossLogManagerLogger.java
+++ b/src/main/java/org/jboss/logging/JBossLogManagerLogger.java
@@ -36,10 +36,13 @@ final class JBossLogManagerLogger extends Logger {
     }
 
     protected void doLog(final Level level, final String loggerClassName, final Object message, final Object[] parameters, final Throwable thrown) {
-        if (parameters == null) {
-            logger.log(loggerClassName, translate(level), String.valueOf(message), thrown);
-        } else {
-            logger.log(loggerClassName, translate(level), String.valueOf(message), ExtLogRecord.FormatStyle.MESSAGE_FORMAT, parameters, thrown);
+        java.util.logging.Level translatedLevel = translate(level);
+        if (logger.isLoggable(translatedLevel)) {
+          if (parameters == null) {
+            logger.log(loggerClassName, translatedLevel, String.valueOf(message), thrown);
+          } else {
+            logger.log(loggerClassName, translatedLevel, String.valueOf(message), ExtLogRecord.FormatStyle.MESSAGE_FORMAT, parameters, thrown);
+          }
         }
     }
 


### PR DESCRIPTION
`JBossLogManagerLogger#doLog` always converts the message to a String
even if the level isn't loggable. For example `LogAuditProvider#audit`
does trace logging which ends up calling `AuditEvent#toString` even if
trace logging isn't enabled. In our case this results in a lot of
allocations outside of TLABs.

Issue: JBLOGGING-100
https://issues.jboss.org/browse/JBLOGGING-100
