### PR TITLE
JBLOGGING-106 Changed Log4jLoggerProvider to remove the NDC instead of

### DIFF
--- a/src/main/java/org/jboss/logging/Log4jLoggerProvider.java
+++ b/src/main/java/org/jboss/logging/Log4jLoggerProvider.java
@@ -51,7 +51,7 @@ final class Log4jLoggerProvider implements LoggerProvider {
     }
 
     public void clearNdc() {
-        NDC.clear();
+        NDC.remove();
     }
 
     public String getNdc() {


### PR DESCRIPTION
clear which will free reference to the current thread.
