### PR TITLE
MDC and NDC updates

### DIFF
--- a/src/main/java/org/jboss/logging/AbstractMdcLoggerProvider.java
+++ b/src/main/java/org/jboss/logging/AbstractMdcLoggerProvider.java
@@ -26,6 +26,13 @@ abstract class AbstractMdcLoggerProvider extends AbstractLoggerProvider {
 
     private final ThreadLocal<Map<String, Object>> mdcMap = new ThreadLocal<Map<String, Object>>();
 
+    public void clearMdc() {
+        final Map<String, Object> map = mdcMap.get();
+        if (map != null) {
+            map.clear();
+        }
+    }
+
     public Object getMdc(String key) {
         return mdcMap.get() == null ? null : mdcMap.get().get(key);
     }

--- a/src/main/java/org/jboss/logging/AbstractMdcLoggerProvider.java
+++ b/src/main/java/org/jboss/logging/AbstractMdcLoggerProvider.java
@@ -18,6 +18,7 @@
 
 package org.jboss.logging;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,7 +31,8 @@ abstract class AbstractMdcLoggerProvider extends AbstractLoggerProvider {
     }
 
     public Map<String, Object> getMdcMap() {
-        return mdcMap.get();
+        final Map<String, Object> map = mdcMap.get();
+        return map == null ? Collections.<String, Object>emptyMap() : map;
     }
 
     public Object putMdc(String key, Object value) {

--- a/src/main/java/org/jboss/logging/JBossLogManagerProvider.java
+++ b/src/main/java/org/jboss/logging/JBossLogManagerProvider.java
@@ -98,6 +98,10 @@ final class JBossLogManagerProvider implements LoggerProvider {
         }
     }
 
+    public void clearMdc() {
+        MDC.clear();
+    }
+
     public Object putMdc(final String key, final Object value) {
         return MDC.put(key, String.valueOf(value));
     }

--- a/src/main/java/org/jboss/logging/Log4j2LoggerProvider.java
+++ b/src/main/java/org/jboss/logging/Log4j2LoggerProvider.java
@@ -31,6 +31,11 @@ final class Log4j2LoggerProvider implements LoggerProvider {
     }
 
     @Override
+    public void clearMdc() {
+        ThreadContext.clearMap();
+    }
+
+    @Override
     public Object putMdc(String key, Object value) {
         try {
             return ThreadContext.get(key);

--- a/src/main/java/org/jboss/logging/Log4jLoggerProvider.java
+++ b/src/main/java/org/jboss/logging/Log4jLoggerProvider.java
@@ -30,6 +30,10 @@ final class Log4jLoggerProvider implements LoggerProvider {
         return new Log4jLogger("".equals(name) ? "ROOT" : name);
     }
 
+    public void clearMdc() {
+        MDC.clear();
+    }
+
     public Object getMdc(String key) {
         return MDC.get(key);
     }

--- a/src/main/java/org/jboss/logging/Log4jLoggerProvider.java
+++ b/src/main/java/org/jboss/logging/Log4jLoggerProvider.java
@@ -18,6 +18,7 @@
 
 package org.jboss.logging;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.log4j.MDC;
@@ -33,9 +34,10 @@ final class Log4jLoggerProvider implements LoggerProvider {
         return MDC.get(key);
     }
 
-    @SuppressWarnings("unchecked")
     public Map<String, Object> getMdcMap() {
-        return MDC.getContext();
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> map = MDC.getContext();
+        return map == null ? Collections.<String, Object>emptyMap() : map;
     }
 
     public Object putMdc(String key, Object val) {

--- a/src/main/java/org/jboss/logging/LoggerProvider.java
+++ b/src/main/java/org/jboss/logging/LoggerProvider.java
@@ -39,6 +39,11 @@ public interface LoggerProvider {
     Logger getLogger(String name);
 
     /**
+     * Removes all entries from the message diagnostics context.
+     */
+    void clearMdc();
+
+    /**
      * Puts the value onto the message diagnostics context.
      *
      * @param key   the key for the value

--- a/src/main/java/org/jboss/logging/LoggerProvider.java
+++ b/src/main/java/org/jboss/logging/LoggerProvider.java
@@ -18,30 +18,108 @@
 
 package org.jboss.logging;
 
+import java.util.Collections;
 import java.util.Map;
 
+/**
+ * A contract for the log provider implementation.
+ */
 public interface LoggerProvider {
+    /**
+     * Returns a logger which is backed by a logger from the log provider.
+     *
+     * <p>
+     * <b>Note:</b> this should never be {@code null}
+     * </p>
+     *
+     * @param name the name of the logger
+     *
+     * @return a logger for the log provider logger.
+     */
     Logger getLogger(String name);
 
+    /**
+     * Puts the value onto the message diagnostics context.
+     *
+     * @param key   the key for the value
+     * @param value the value
+     *
+     * @return the previous value set or {@code null} if no value was set
+     */
     Object putMdc(String key, Object value);
 
+    /**
+     * Returns the value for the key on the message diagnostics context or {@code null} if no value was found.
+     *
+     * @param key the key to lookup the value for
+     *
+     * @return the value or {@code null} if not found
+     */
     Object getMdc(String key);
 
+    /**
+     * Removes the value from the message diagnostics context.
+     *
+     * @param key the key of the value to remove
+     */
     void removeMdc(String key);
 
+    /**
+     * Returns the map from the context.
+     *
+     * <p>
+     * Note that in most implementations this is an expensive operation and should be used sparingly.
+     * </p>
+     *
+     * @return the map from the context or an {@linkplain Collections#emptyMap() empty map} if the context is {@code
+     * null}
+     */
     Map<String, Object> getMdcMap();
 
+    /**
+     * Clears the nested diagnostics context.
+     */
     void clearNdc();
 
+    /**
+     * Retrieves the current values set for the nested diagnostics context.
+     *
+     * @return the current value set or {@code null} if no value was set
+     */
     String getNdc();
 
+    /**
+     * The current depth of the nested diagnostics context.
+     *
+     * @return the current depth of the stack
+     */
     int getNdcDepth();
 
+    /**
+     * Pops top value from the stack and returns it.
+     *
+     * @return the top value from the stack or an empty string if no value was set
+     */
     String popNdc();
 
+    /**
+     * Peeks at the top value from the stack and returns it.
+     *
+     * @return the value or an empty string
+     */
     String peekNdc();
 
+    /**
+     * Pushes a value to the nested diagnostics context stack.
+     *
+     * @param message the message to push
+     */
     void pushNdc(String message);
 
+    /**
+     * Sets maximum depth of the stack removing any entries below the maximum depth.
+     *
+     * @param maxDepth the maximum depth to set
+     */
     void setNdcMaxDepth(int maxDepth);
 }

--- a/src/main/java/org/jboss/logging/MDC.java
+++ b/src/main/java/org/jboss/logging/MDC.java
@@ -18,25 +18,59 @@
 
 package org.jboss.logging;
 
+import java.util.Collections;
 import java.util.Map;
 
+/**
+ * Mapped diagnostic context. Each log provider implementation may behave different.
+ */
 public final class MDC {
 
     private MDC() {
     }
 
+    /**
+     * Puts the value onto the context.
+     *
+     * @param key the key for the value
+     * @param val the value
+     *
+     * @return the previous value set or {@code null} if no value was set
+     */
     public static Object put(String key, Object val) {
         return LoggerProviders.PROVIDER.putMdc(key, val);
     }
 
+    /**
+     * Returns the value for the key or {@code null} if no value was found.
+     *
+     * @param key the key to lookup the value for
+     *
+     * @return the value or {@code null} if not found
+     */
     public static Object get(String key) {
         return LoggerProviders.PROVIDER.getMdc(key);
     }
 
+    /**
+     * Removes the value from the context.
+     *
+     * @param key the key of the value to remove
+     */
     public static void remove(String key) {
         LoggerProviders.PROVIDER.removeMdc(key);
     }
 
+    /**
+     * Returns the map from the context.
+     *
+     * <p>
+     * Note that in most implementations this is an expensive operation and should be used sparingly.
+     * </p>
+     *
+     * @return the map from the context or an {@linkplain Collections#emptyMap() empty map} if the context is {@code
+     * null}
+     */
     public static Map<String, Object> getMap() {
         return LoggerProviders.PROVIDER.getMdcMap();
     }

--- a/src/main/java/org/jboss/logging/MDC.java
+++ b/src/main/java/org/jboss/logging/MDC.java
@@ -74,4 +74,11 @@ public final class MDC {
     public static Map<String, Object> getMap() {
         return LoggerProviders.PROVIDER.getMdcMap();
     }
+
+    /**
+     * Clears the message diagnostics context.
+     */
+    public static void clear() {
+        LoggerProviders.PROVIDER.clearMdc();
+    }
 }

--- a/src/main/java/org/jboss/logging/NDC.java
+++ b/src/main/java/org/jboss/logging/NDC.java
@@ -23,30 +23,63 @@ public final class NDC {
     private NDC() {
     }
 
+    /**
+     * Clears the nested diagnostics context.
+     */
     public static void clear() {
         LoggerProviders.PROVIDER.clearNdc();
     }
 
+    /**
+     * Retrieves the current values set for the nested diagnostics context.
+     *
+     * @return the current value set or {@code null} if no value was set
+     */
     public static String get() {
         return LoggerProviders.PROVIDER.getNdc();
     }
 
+    /**
+     * The current depth of the nested diagnostics context.
+     *
+     * @return the current depth of the stack
+     */
     public static int getDepth() {
         return LoggerProviders.PROVIDER.getNdcDepth();
     }
 
+    /**
+     * Pops top value from the stack and returns it.
+     *
+     * @return the top value from the stack or an empty string if no value was set
+     */
     public static String pop() {
         return LoggerProviders.PROVIDER.popNdc();
     }
 
+    /**
+     * Peeks at the top value from the stack and returns it.
+     *
+     * @return the value or an empty string
+     */
     public static String peek() {
         return LoggerProviders.PROVIDER.peekNdc();
     }
 
+    /**
+     * Pushes a value to the nested diagnostics context stack.
+     *
+     * @param message the message to push
+     */
     public static void push(String message) {
         LoggerProviders.PROVIDER.pushNdc(message);
     }
 
+    /**
+     * Sets maximum depth of the stack removing any entries below the maximum depth.
+     *
+     * @param maxDepth the maximum depth to set
+     */
     public static void setMaxDepth(int maxDepth) {
         LoggerProviders.PROVIDER.setNdcMaxDepth(maxDepth);
     }

--- a/src/main/java/org/jboss/logging/Slf4jLoggerProvider.java
+++ b/src/main/java/org/jboss/logging/Slf4jLoggerProvider.java
@@ -18,7 +18,9 @@
 
 package org.jboss.logging;
 
+import java.util.Collections;
 import java.util.Map;
+
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.slf4j.spi.LocationAwareLogger;
@@ -29,7 +31,8 @@ final class Slf4jLoggerProvider extends AbstractLoggerProvider implements Logger
         org.slf4j.Logger l = LoggerFactory.getLogger(name);
         try {
             return new Slf4jLocationAwareLogger(name, (LocationAwareLogger) l);
-        } catch (Throwable ignored) {}
+        } catch (Throwable ignored) {
+        }
         return new Slf4jLogger(name, l);
     }
 
@@ -53,8 +56,9 @@ final class Slf4jLoggerProvider extends AbstractLoggerProvider implements Logger
         MDC.remove(key);
     }
 
-    @SuppressWarnings({ "unchecked" })
     public Map<String, Object> getMdcMap() {
-        return MDC.getCopyOfContextMap();
+        @SuppressWarnings({"unchecked"})
+        final Map<String, Object> map = MDC.getCopyOfContextMap();
+        return map == null ? Collections.<String, Object>emptyMap() : map;
     }
 }

--- a/src/main/java/org/jboss/logging/Slf4jLoggerProvider.java
+++ b/src/main/java/org/jboss/logging/Slf4jLoggerProvider.java
@@ -36,6 +36,10 @@ final class Slf4jLoggerProvider extends AbstractLoggerProvider implements Logger
         return new Slf4jLogger(name, l);
     }
 
+    public void clearMdc() {
+        MDC.clear();
+    }
+
     public Object putMdc(final String key, final Object value) {
         try {
             return MDC.get(key);


### PR DESCRIPTION
[JBLOGGING-116] ensure an empty map is returned if the mapped diagnostics context is `null`

[JBLOGGING-115] Added a `MDC.clear()` and `LoggerProvider.clearMdc()`