### PR TITLE
Webapp memory leak due to a  java.util.logging.Level subclass (Tomcat, OpenJPA, javax.validation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# jboss-logging
+This version does not create a subclass of <a href="http://docs.oracle.com/javase/7/docs/api/java/util/logging/Level.html">java.util.logging.Level</a> 
+instances. It may create a webapp memory leak on hotdeployments in servlet engines. 
+This will happen if jboss-logging.jar is provided by mywebapp/WEB-INF/lib folder.
+
+https://issues.jboss.org/browse/JBLOGGING-66<br/>
+http://bugs.java.com/view_bug.do?bug_id=6543126<br/>
+http://java.jiderhamn.se/2012/01/01/classloader-leaks-ii-find-and-work-around-unwanted-references/#beanvalidation<br/>
+
+I have witnessed this in OpenJPA+javaxvalidation+Tomcat environment where mywebapp.war provides jar libraries.
+Modified two classes to fix memory leak.<br/>
+org.jboss.logging.JDKLevel<br/>
+org.jboss.logging.JDKLogger<br/>

--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ I have witnessed this in OpenJPA+javaxvalidation+Tomcat environment where myweba
 Modified two classes to fix memory leak.<br/>
 org.jboss.logging.JDKLevel<br/>
 org.jboss.logging.JDKLogger<br/>
+
+<b>Build</b><br/>
+Clone files to a local folder<br/>
+Run <i>mvn package</i> in a command console<br/>
+Copy a new target/jboss-logging.jar file to a webapp<br/>
+

--- a/src/main/java/org/jboss/logging/JDKLevel.java
+++ b/src/main/java/org/jboss/logging/JDKLevel.java
@@ -27,19 +27,27 @@ final class JDKLevel extends Level {
 
     private static final long serialVersionUID = 1L;
 
+	// Never subclass Level class or it may create webapp memory leak if this library was inside webapp/lib folder
+	// http://bugs.java.com/view_bug.do?bug_id=6543126
+	// http://java.jiderhamn.se/2012/01/01/classloader-leaks-ii-find-and-work-around-unwanted-references/#beanvalidation
+	// @see also JDKLogger.java translate() method
+	
     protected JDKLevel(final String name, final int value) {
-        super(name, value);
+        super(name, value);		
+		throw new IllegalArgumentException("Subclass of java.util.logging.Level disabled due to a potential memory leak");
     }
 
     protected JDKLevel(final String name, final int value, final String resourceBundleName) {
         super(name, value, resourceBundleName);
+		throw new IllegalArgumentException("Subclass of java.util.logging.Level disabled due to a potential memory leak");		
     }
 
-    public static final JDKLevel FATAL = new JDKLevel("FATAL", 1100);
+    /*public static final JDKLevel FATAL = new JDKLevel("FATAL", 1100);
     public static final JDKLevel ERROR = new JDKLevel("ERROR", 1000);
     public static final JDKLevel WARN = new JDKLevel("WARN", 900);
     @SuppressWarnings("hiding")
     public static final JDKLevel INFO = new JDKLevel("INFO", 800);
     public static final JDKLevel DEBUG = new JDKLevel("DEBUG", 500);
-    public static final JDKLevel TRACE = new JDKLevel("TRACE", 400);
+    public static final JDKLevel TRACE = new JDKLevel("TRACE", 400);*/
+	
 }

--- a/src/main/java/org/jboss/logging/JDKLogger.java
+++ b/src/main/java/org/jboss/logging/JDKLogger.java
@@ -67,14 +67,14 @@ final class JDKLogger extends Logger {
 
     private static java.util.logging.Level translate(final Level level) {
         if (level != null) switch (level) {
-            case FATAL: return JDKLevel.FATAL;
-            case ERROR: return JDKLevel.ERROR;
-            case WARN:  return JDKLevel.WARN;
-            case INFO:  return JDKLevel.INFO;
-            case DEBUG: return JDKLevel.DEBUG;
-            case TRACE: return JDKLevel.TRACE;
+            case FATAL: return java.util.logging.Level.SEVERE; //JDKLevel.FATAL;
+            case ERROR: return java.util.logging.Level.SEVERE; //JDKLevel.ERROR;
+            case WARN:  return java.util.logging.Level.WARNING; //JDKLevel.WARN;
+            case INFO:  return java.util.logging.Level.INFO; //JDKLevel.INFO;
+            case DEBUG: return java.util.logging.Level.FINE; //JDKLevel.DEBUG;
+            case TRACE: return java.util.logging.Level.FINER; //JDKLevel.TRACE;
         }
-        return JDKLevel.ALL;
+        return java.util.logging.Level.ALL; //JDKLevel.ALL;
     }
 
     public boolean isEnabled(final Level level) {


### PR DESCRIPTION
jboss-logging creates a subclass of JDK java.util.logging.Level instances, it may create a webapp memory leak on hotdeployments. This will happen in Tomcat if this jar is inside mywebapp/WEB-INF/lib folder. Tomcat is not a full featured J2EE environment so it most likely is distributed inside a web application.
