### PR TITLE
JBLOGGING-126: Fix log4j detection in OSGi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
                             ${project.groupId}.*;version=${project.version};-split-package:=error
                         </Export-Package>
                         <Import-Package>
+                            org.apache.log4j.config;resolution:=optional,
                             *;resolution:=optional
                         </Import-Package>
                     </instructions>


### PR DESCRIPTION
This changes does fix JBLOGGING-126 by adding an explicit, optional
package import on 'org.apache.log4j.config' in order to allow the
discovery of 'org.apache.log4j.config.PropertySetter'.

Signed-off-by: Jens Reimann <jreimann@redhat.com>