### PR TITLE
 Add a way to implement delegating logger providers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.logging</groupId>
     <artifactId>jboss-logging</artifactId>
-    <version>3.3.2.Final-SNAPSHOT</version>
+    <version>3.4.0.Final-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>JBoss Logging 3</name>
     <url>http://www.jboss.org</url>

--- a/src/main/java/org/jboss/logging/DelegatingLoggerProvider.java
+++ b/src/main/java/org/jboss/logging/DelegatingLoggerProvider.java
@@ -1,0 +1,107 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.logging;
+
+import java.util.Map;
+
+public class DelegatingLoggerProvider implements LoggerProvider {
+
+	private volatile LoggerProvider delegate;
+
+	protected final LoggerProvider getDelegate() {
+		LoggerProvider theDelegate = delegate;
+		if ( theDelegate != null ) {
+			return theDelegate;
+		}
+		synchronized (this) {
+			theDelegate = delegate;
+			if ( theDelegate == null ) {
+				theDelegate = LoggerProviders.findDelegate( getClass() );
+				delegate = theDelegate;
+			}
+			return theDelegate;
+		}
+	}
+
+	@Override
+	public Logger getLogger(final String name) {
+		return getDelegate().getLogger(name);
+	}
+
+	@Override
+	public void clearMdc() {
+		getDelegate().clearMdc();
+	}
+
+	@Override
+	public Object putMdc(String key, Object value) {
+		return getDelegate().putMdc( key, value );
+	}
+
+	@Override
+	public Object getMdc(String key) {
+		return getDelegate().getMdc( key );
+	}
+
+	@Override
+	public void removeMdc(String key) {
+		getDelegate().removeMdc( key );
+	}
+
+	@Override
+	public Map<String, Object> getMdcMap() {
+		return getDelegate().getMdcMap();
+	}
+
+	@Override
+	public void clearNdc() {
+		getDelegate().clearNdc();
+	}
+
+	@Override
+	public String getNdc() {
+		return getDelegate().getNdc();
+	}
+
+	@Override
+	public int getNdcDepth() {
+		return getDelegate().getNdcDepth();
+	}
+
+	@Override
+	public String popNdc() {
+		return getDelegate().popNdc();
+	}
+
+	@Override
+	public String peekNdc() {
+		return getDelegate().peekNdc();
+	}
+
+	@Override
+	public void pushNdc(String message) {
+		getDelegate().pushNdc( message );
+	}
+
+	@Override
+	public void setNdcMaxDepth(int maxDepth) {
+		getDelegate().setNdcMaxDepth( maxDepth );
+	}
+}

--- a/src/main/java/org/jboss/logging/LoggerProviders.java
+++ b/src/main/java/org/jboss/logging/LoggerProviders.java
@@ -31,10 +31,14 @@ final class LoggerProviders {
     static final LoggerProvider PROVIDER = find();
 
     private static LoggerProvider find() {
-        return findProvider();
+        return findProvider(null);
     }
 
-    private static LoggerProvider findProvider() {
+    static LoggerProvider findDelegate(Class<?> ignoredServiceClass) {
+        return findProvider(ignoredServiceClass);
+    }
+
+    private static LoggerProvider findProvider(Class<?> ignoredServiceClass) {
         // Since the impl classes refer to the back-end frameworks directly, if this classloader can't find the target
         // log classes, then it doesn't really matter if they're possibly available from the TCCL because we won't be
         // able to find it anyway
@@ -71,6 +75,7 @@ final class LoggerProviders {
                 try {
                     if (!iter.hasNext()) break;
                     LoggerProvider provider = iter.next();
+                    if (ignoredServiceClass != null && ignoredServiceClass.isInstance(provider)) continue;
                     // Attempt to get a logger, if it fails keep trying
                     logProvider(provider, "service loader");
                     return provider;


### PR DESCRIPTION
This change is necessary to a pull request in the JBoss Logging Tools project: https://github.com/jboss-logging/jboss-logging-tools/pull/72

It allows a "delegating" logger provider to be defined, i.e. a logger provider that will decorate another provider and forward the calls.

See here for an example of use: https://github.com/jboss-logging/jboss-logging-tools/pull/72/files#diff-e79fc765a1119a048797761921413563