### PR TITLE
Fix LoggerProvider instantiation through ServiceLoader

### DIFF
--- a/src/main/java/org/jboss/logging/JBossLogManagerProvider.java
+++ b/src/main/java/org/jboss/logging/JBossLogManagerProvider.java
@@ -35,6 +35,12 @@ final class JBossLogManagerProvider implements LoggerProvider {
     private static final AttachmentKey<Logger> KEY = new AttachmentKey<Logger>();
     private static final AttachmentKey<ConcurrentMap<String, Logger>> LEGACY_KEY = new AttachmentKey<ConcurrentMap<String, Logger>>();
 
+    /**
+    * A zero-argument constructor needs to be accessible from {@link java.util.ServiceLoader}
+    */
+    public JBossLogManagerProvider() {
+    }
+
     public Logger getLogger(final String name) {
         final SecurityManager sm = System.getSecurityManager();
         if (sm != null) {

--- a/src/main/java/org/jboss/logging/JDKLoggerProvider.java
+++ b/src/main/java/org/jboss/logging/JDKLoggerProvider.java
@@ -20,6 +20,12 @@ package org.jboss.logging;
 
 final class JDKLoggerProvider extends AbstractMdcLoggerProvider implements LoggerProvider {
 
+    /**
+    * A zero-argument constructor needs to be accessible from {@link java.util.ServiceLoader}
+    */
+    public JDKLoggerProvider() {
+    }
+
     public Logger getLogger(final String name) {
         return new JDKLogger(name);
     }

--- a/src/main/java/org/jboss/logging/Log4j2LoggerProvider.java
+++ b/src/main/java/org/jboss/logging/Log4j2LoggerProvider.java
@@ -25,6 +25,12 @@ import org.apache.logging.log4j.ThreadContext;
 
 final class Log4j2LoggerProvider implements LoggerProvider {
 
+    /**
+    * A zero-argument constructor needs to be accessible from {@link java.util.ServiceLoader}
+    */
+    public Log4j2LoggerProvider() {
+    }
+
     @Override
     public Log4j2Logger getLogger(String name) {
         return new Log4j2Logger(name);

--- a/src/main/java/org/jboss/logging/Log4jLoggerProvider.java
+++ b/src/main/java/org/jboss/logging/Log4jLoggerProvider.java
@@ -26,6 +26,12 @@ import org.apache.log4j.NDC;
 
 final class Log4jLoggerProvider implements LoggerProvider {
 
+    /**
+    * A zero-argument constructor needs to be accessible from {@link java.util.ServiceLoader}
+    */
+    public Log4jLoggerProvider() {
+    }
+
     public Logger getLogger(final String name) {
         return new Log4jLogger("".equals(name) ? "ROOT" : name);
     }

--- a/src/main/java/org/jboss/logging/Slf4jLoggerProvider.java
+++ b/src/main/java/org/jboss/logging/Slf4jLoggerProvider.java
@@ -27,6 +27,12 @@ import org.slf4j.spi.LocationAwareLogger;
 
 final class Slf4jLoggerProvider extends AbstractLoggerProvider implements LoggerProvider {
 
+    /**
+    * A zero-argument constructor needs to be accessible from {@link java.util.ServiceLoader}
+    */
+    public Slf4jLoggerProvider() {
+    }
+
     public Logger getLogger(final String name) {
         org.slf4j.Logger l = LoggerFactory.getLogger(name);
         try {


### PR DESCRIPTION
LoggerProvider implementations all have an implicit default constructor.

These constructors are not accessible from java.util.ServiceLoader because its invocation is done from a different package.

The fix adds a zero-argument constructor as required by java.util.ServiceLoader