### PR TITLE
[JBLOGGING-140] Avoid ClassCastException in Slf4jLoggerProvider

### DIFF
--- a/src/main/java/org/jboss/logging/Slf4jLoggerProvider.java
+++ b/src/main/java/org/jboss/logging/Slf4jLoggerProvider.java
@@ -30,9 +30,8 @@ final class Slf4jLoggerProvider extends AbstractLoggerProvider implements Logger
 
     public Logger getLogger(final String name) {
         org.slf4j.Logger l = LoggerFactory.getLogger(name);
-        try {
+        if (l instanceof LocationAwareLogger) {
             return new Slf4jLocationAwareLogger(name, (LocationAwareLogger) l);
-        } catch (Throwable ignored) {
         }
         return new Slf4jLogger(name, l);
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/JBLOGGING-140

Replace the unconditional cast with an instanceof check.