### PR TITLE
Fixed NullPointerException

### DIFF
--- a/src/main/java/org/jboss/logging/LoggerProviders.java
+++ b/src/main/java/org/jboss/logging/LoggerProviders.java
@@ -147,7 +147,7 @@ final class LoggerProviders {
 
     private static void logProvider(final LoggerProvider provider, final String via) {
         // Log a debug message indicating which logger we are using
-        final Logger logger = provider.getLogger(LoggerProviders.class.getPackage().getName());
+        final Logger logger = provider.getLogger(LoggerProviders.class.getName());
         if (via == null) {
             logger.debugf("Logging Provider: %s", provider.getClass().getName());
         } else {


### PR DESCRIPTION
At line 150 getPackage() method was returning null when code is run outside of application server and it was causing NullPointerException. Removed getPackage() call to remove NullPointerException.