### PR TITLE
[JBLOGGING-149] Use a hard-coded logger name for the rare case where …

### DIFF
--- a/src/main/java/org/jboss/logging/LoggerProviders.java
+++ b/src/main/java/org/jboss/logging/LoggerProviders.java
@@ -147,7 +147,7 @@ final class LoggerProviders {
 
     private static void logProvider(final LoggerProvider provider, final String via) {
         // Log a debug message indicating which logger we are using
-        final Logger logger = provider.getLogger(LoggerProviders.class.getPackage().getName());
+        final Logger logger = provider.getLogger("org.jboss.logging");
         if (via == null) {
             logger.debugf("Logging Provider: %s", provider.getClass().getName());
         } else {


### PR DESCRIPTION
…the Class.getPackage() may return null.

https://issues.redhat.com/browse/JBLOGGING-149