### PR TITLE
Fixes issue with JUL when using modules

### DIFF
--- a/src/main/java/module-info.yml
+++ b/src/main/java/module-info.yml
@@ -9,6 +9,8 @@ requires:
     static: true
   - module: org.apache.logging.log4j
     static: true
+  - module: java.logging
+    static: true
 
 uses:
   - org.jboss.logging.LoggerProvider


### PR DESCRIPTION
- without this I cannot use hibernate-validator with modules on GlassFish

Signed-off-by: David Matějček <david.matejcek@omnifish.ee>