### PR TITLE
Add java.base module explicitly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,10 @@
                         <goals>
                             <goal>generate</goal>
                         </goals>
+                        <configuration>
+                            <!-- We are going to add the required modules ourselves in module-info.yml -->
+                            <addMandatory>false</addMandatory>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/module-info.yml
+++ b/src/main/java/module-info.yml
@@ -1,6 +1,11 @@
 name: org.jboss.logging
 
 requires:
+    # Adding a dependency on java.base explicitly as mandated here to address https://bugs.openjdk.org/browse/JDK-8299769
+    # io.github.dmlloyd.module-info:module-info:2.0 version of the plugin adds it as ACC_SYNTHETIC ACC_MANDATED
+    # resulting in build errors on JDK21+
+  - module: java.base
+    mandated: true
   - module: org.slf4j
     static: true
   - module: log4j.api # log4j 1, theoretically


### PR DESCRIPTION
While upgrading to the latest version (`3.5.2`), we've discovered that the upgrade of the `io.github.dmlloyd.module-info:module-info` plugin results in creating a module-info file that, when jboss-logging is used on JDK21+ it results in build failures like:

```
[ERROR] Error occurred during initialization of boot layer
[ERROR] java.lang.module.FindException: Error reading module: /var/lib/jenkins/workspace/hibernate-search_main@tmp/maven-repository/org/jboss/logging/jboss-logging/3.5.2.Final/jboss-logging-3.5.2.Final.jar
Caused by: java.lang.module.InvalidModuleDescriptorException: The requires entry for java.base has ACC_SYNTHETIC set
```

looking at the generated module infos by 1.2 and 2.0 versions of plugins:

1.2:
```
SourceFile: "module-info.yml"
Module:
  #5,0                                    // "org.jboss.logging"
  #6                                      // 3.5.3.Final-SNAPSHOT
  5                                       // requires
    #8,40                                   // "org.slf4j" ACC_STATIC_PHASE
    #0
    #10,40                                  // "log4j.api" ACC_STATIC_PHASE
    #0
    #12,40                                  // "org.apache.logging.log4j" ACC_STATIC_PHASE
    #0
    #14,40                                  // "java.logging" ACC_STATIC_PHASE
    #0
    #18,8000                                // "java.base" ACC_MANDATED
    #0
  1                                       // exports
    #16,0                                   // org/jboss/logging
  0                                       // opens
  1                                       // uses
    #20                                     // org/jboss/logging/LoggerProvider
  0                                       // provides
ModulePackages:
  #16                                     // org.jboss.logging
```
2.0:
```
SourceFile: "module-info.yml"
Module:
  #5,0                                    // "org.jboss.logging"
  #6                                      // 3.5.3.Final-SNAPSHOT
  5                                       // requires
    #12,9000                                // "java.base" ACC_SYNTHETIC ACC_MANDATED
    #0
    #14,40                                  // "java.logging" ACC_STATIC_PHASE
    #0
    #16,40                                  // "log4j.api" ACC_STATIC_PHASE
    #0
    #18,40                                  // "org.apache.logging.log4j" ACC_STATIC_PHASE
    #0
    #20,40                                  // "org.slf4j" ACC_STATIC_PHASE
    #0
  1                                       // exports
    #8,0                                    // org/jboss/logging
  0                                       // opens
  1                                       // uses
    #10                                     // org/jboss/logging/LoggerProvider
  0                                       // provides
ModulePackages:
  #8                                      // org.jboss.logging
```

Automatically added `java.base` has a `ACC_SYNTHETIC` flag applied, resulting in triggering this error on JDK21+ (https://bugs.openjdk.org/browse/JDK-8299769)

Adding the `java.base` explicitly with the flags we want (`ACC_MANDATED`) helps solve this.

The question is... should we apply these changes here, or should we update the plugin instead and then use a new version of it here? (if it's updating the plugin - let me know I'll submit a PR to the plugin then 😄) 