### PR TITLE
CI: Also add the latest JDK EA (22-ea) to the list of tested JDKs (optional check).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
       - name: Build and Test on Java ${{ matrix.java }}
-        run: mvn clean install
+        run: mvn clean install -fae
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         # Keep this list as: all supported LTS JDKs, the latest GA JDK, and the latest EA JDK (if available/optional).
-        java: [11, 17, 21]
+        java: [11, 17, 21, 22-ea]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
May I interest you @jamezp in expanding the tested JDK matrix? Basically it's a way to discover problems early like at the moment, the JDK 22 EA (should not be a required check) doesn't work with jboss-logging (is this known?) - which is unfortunate for projects that do want to test with 22-ea and use jboss-logging and thus cannot.